### PR TITLE
Fix the path of RoboComp's libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Let's now tell Linux where to find RoboComp's libraries:
 
 and add the following line:
 
-    /opt/robocomp/libs/
+    /opt/robocomp/lib/
    
 save the file and type:
 


### PR DESCRIPTION
The library path should be `/opt/robocomp/lib/` instead of `/opt/robocomp/libs/` when adding the line to file `ld.so.conf`.