### PR TITLE
Packages Missing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ interfaces in a seamless way. Building new components is done using two domain s
 Make sure you have installed the following packages from the Ubuntu repository:
 
     sudo apt-get update
-    sudo apt-get install git git-annex cmake g++ libgsl0-dev libopenscenegraph-dev cmake-qt-gui zeroc-ice35 freeglut3-dev libboost-system-dev libboost-thread-dev qt4-dev-tools yakuake openjdk-7-jre python-pip  python-pyparsing python-numpy python-pyside pyside-tools
+    sudo apt-get install git git-annex cmake g++ libgsl0-dev libopenscenegraph-dev cmake-qt-gui zeroc-ice35 freeglut3-dev libboost-system-dev libboost-thread-dev qt4-dev-tools yakuake openjdk-7-jre python-pip  python-pyparsing python-numpy python-pyside pyside-tools libxt-dev libgl1-mesa-dev-lts-utopic libglu1-mesa-dev pyqt4-dev-tools qt4-designer
     
 ###RoboComp core libraries
 
@@ -23,7 +23,11 @@ Now we will create a symbolic link so RobComp can find everything. You will have
 
     sudo ln -s /home/<your-linux-user> /home/robocomp 
     
-Edit your ~/.bashrc file and add these lines at the end:
+Edit your ~/.bashrc file 
+
+    gedit ~/.bashrc
+
+Add these lines at the end:
 
     export ROBOCOMP=/home/<your-linux-user>/robocomp
     export PATH=$PATH:/opt/robocomp/bin


### PR DESCRIPTION
libxt-dev libgl1-mesa-dev-lts-utopic libglu1-mesa-dev

These packages are required while installing freeglut3-dev else there will be a unity-control-center unmet dependencies error.

pyqt4-dev-tools qt4-designer

This package is required as there arises a make error “make pyquic4 common not found” while executing make.