### PR TITLE
Fix OpenMP library issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_custom_target(uninstall "${CMAKE_COMMAND}" -P
                   "${RoboComp_BINARY_DIR}/uninstall_target.cmake")
 
 # RoboComp global dependencies
+find_package(OpenMP REQUIRED) ## search OpenMP libs
 if(OPENMP_FOUND)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")


### PR DESCRIPTION
The CMakeLists.txt was not searching for OpenMP libraries, so added a line "find_package(OpenMP REQUIRED)" . Please see through the addition made and its relevance while looking for OpenMP and merge the request.

Regards,
Abhishek