### PR TITLE
Changes to README.md and cmake/robocomp.cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Done! Now let's compile and install the whole thing:
 
     cd robocomp
     cmake .
+#IF the cmake . returns " file Internal CMake error when trying to open file: <file_name> for writing.Use the following commands
+    sudo gedit ~/.profile
+	Add these lines at the end:
+	export ROBOCOMP=/home/<your-linux-user>/robocomp
+    	export PATH=$PATH:/opt/robocomp/bin
+    sudo gedit /etc/sudoers
+	Add these lines at the end:
+	Defaults   env_keep += "ROBOCOMP" 
+#Also you must add other environment variables such as ICEROOT, SLCIEPATH, etc.
+#LOG out and again log-in to process the changes
+    sudo cmake.
     make
     sudo make install
     

--- a/cmake/robocomp.cmake
+++ b/cmake/robocomp.cmake
@@ -26,14 +26,14 @@ MACRO( ROBOCOMP_INITIALIZE )
 	ENDIF (NOT ${ICEROOT} EQUAL "")
   INCLUDE_DIRECTORIES (
     .
-    ${ARGN}/classes/
-    ${ARGN}/libs/
-    ${ARGN}/interfaces/
+    ${ARGN}classes/
+    ${ARGN}libs/
+    ${ARGN}interfaces/
     ${CMAKE_BINARY_DIR}
     ${ICEROOT}/include/
   )
   # Set interfaces directory
-  SET(RoboComp_INTERFACES_DIR "${ARGN}/interfaces/")
+  SET(RoboComp_INTERFACES_DIR "${ARGN}/interfaces")
   # Set libraries
 
   message(STATUS ${OSGUTIL_LIBRARY})

--- a/cmake/robocomp.cmake
+++ b/cmake/robocomp.cmake
@@ -33,7 +33,7 @@ MACRO( ROBOCOMP_INITIALIZE )
     ${ICEROOT}/include/
   )
   # Set interfaces directory
-  SET(RoboComp_INTERFACES_DIR "${ARGN}/interfaces")
+  SET(RoboComp_INTERFACES_DIR "${ARGN}interfaces")
   # Set libraries
 
   message(STATUS ${OSGUTIL_LIBRARY})


### PR DESCRIPTION
1) README.md

Just running the command cmake ., sometimes returns " file Internal CMake error when trying to open file: <file_name> for writing" . So to get rid of this we may use sudo cmake . . Now sudo causes the calling of environment variables like "$ENV{ICEROOT} return " " value. To avoid that I have given instructions regarding the same.

2) cmake/robocomp.cmake

This file has environment variable ${ARGN} set to "home/USER/robocomp/". The setting of directory paths like " ${ARGN}/classes/" makes the path "home/USER/robocomp//classes" , which is a faulty path. Similarly with ${ARGN}/interfaces/.

Please review the changes made and merge the request.

Regards,
Abhishek