### PR TITLE
error in Install.py script.

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -5,7 +5,7 @@ Created on Sat Feb 14 19:36:39 2015
 @author: pbustos
 """
 
-import os, sys
+import os, sys, pprint, subprocess
 from subprocess import call
 
 modules = ["git","git-annex","cmake","g++","libgsl0-dev","libopenscenegraph-dev","cmake-qt-gui",
@@ -20,22 +20,34 @@ command = ["sudo", "apt-get", "install"]
 command.extend(modules)
 call(command)
 
-call(["cd"])
+home = os.getenv("HOME")
+
+os.chdir(home)
+
 call(["git","clone","https://github.com/robocomp/robocomp.git"])
 
 call(["sudo","ln","-s","/opt/robocomp/-1.0","/opt/robocomp"])
-call(["sudo","ln","-s","/home/username","/home/robocomp"])
+call(["sudo","ln","-s",home,"/home/robocomp"])
 
-call(["echo","export ROBOCOMP=/home/username/robocomp",">>","/home/usermane/.bashrc"])
-call(["echo","export PATH=$PATH:/opt/robocomp/bin",">>","/home/usermane/.bashrc"])
-call(["source",".bashrc"])
+call(["echo","export", os.path.join('ROBOCOMP=',home,'robocomp'),">>",os.path.join(home,'.bashrc')])
+call(["echo","export PATH=$PATH:/opt/robocomp/bin",">>",os.path.join(home,'.bashrc')])
 
-call(["cd","robocomp"])
+cmd = ['bash','-c','source .bashrc']
+
+proc = subprocess.Popen(cmd, stdout = subprocess.PIPE)
+
+for line in proc.stdout:
+  (key, _, value) = line.partition("=")
+  os.environ[key] = value
+
+proc.communicate()
+
+
+os.chdir(os.path.join(home,'robocomp'))
+
 call(["cmake","."])
 call(["make"])
 call(["sudo","make","install"])
 
 call(["sudo","echo","/opt/robocomp/lib",">>","/etc/ld.so.conf"])
 call(["sudo","ldconfig"])
-
-#


### PR DESCRIPTION
While executing this script there happens to be a cmake error. Output of the above script : 

﻿ln: failed to create symbolic link ‘/opt/robocomp/-1.0’: File exists
export /home/rc/robocomp >> /home/rc/.bashrc
export PATH=$PATH:/opt/robocomp/bin >> /home/rc/.bashrc
-- The C compiler identification is GNU 4.8.2
-- The CXX compiler identification is GNU 4.8.2
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Try OpenMP C flag = [-fopenmp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Success
-- Try OpenMP CXX flag = [-fopenmp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Success
-- Found OpenMP: -fopenmp  
-- Found OpenMP
-- PYTHON BINDINGS:        NO
-- Looking for Q_WS_X11
-- Looking for Q_WS_X11 - found
-- Looking for Q_WS_WIN
-- Looking for Q_WS_WIN - not found
-- Looking for Q_WS_QWS
-- Looking for Q_WS_QWS - not found
-- Looking for Q_WS_MAC
-- Looking for Q_WS_MAC - not found
-- Found Qt4: /usr/bin/qmake (found version "4.8.6") 
-- Could NOT find Doxygen (missing:  DOXYGEN_EXECUTABLE) 
-- CONFIGURING PACKAGE
-- SRC_DIR is = /home/rc/robocomp
-- Version  = 1.01
-- architecture is: amd64
-- CONFIGURING DONE
-- COMPILING WITHOUT FCL SUPPORT  = 0
CMake Error at tools/rcinnerModelSimulator/src/CMakeLists.txt:46 (INCLUDE):
  include could not find load file:

    /cmake/robocompLocal.cmake


CMake Error at tools/rcinnerModelSimulator/src/CMakeLists.txt:47 (ROBOCOMP_INITIALIZE):

 Unknown CMake command "ROBOCOMP_INITIALIZE".


-- Configuring incomplete, errors occurred!
See also "/home/rc/robocomp/CMakeFiles/CMakeOutput.log".
See also "/home/rc/robocomp/CMakeFiles/CMakeError.log".
make: *** No targets specified and no makefile found.  Stop.
make: *** No rule to make target `install'.  Stop.
/opt/robocomp/lib >> /etc/ld.so.conf