### PR TITLE
Update rcmanager.py

### DIFF
--- a/tools/rcmanager/rcmanager.py
+++ b/tools/rcmanager/rcmanager.py
@@ -894,16 +894,21 @@ class GraphView(QtGui.QWidget):
 if __name__ == '__main__':
 	app = QtGui.QApplication(sys.argv)
 	window = TheThing()
-	window.show()
-
+	
 	if len(sys.argv) > 1:
-		window.openFile(sys.argv[1])
-	ret = -1
+		if os.path.isfile(sys.argv[1]):
+			window.show()
+			window.openFile(sys.argv[1])
 
-	try:
-		ret = app.exec_()
-	except:
-		print 'Some error happened.'
+			ret = -1
+
+			try:
+				ret = app.exec_()
+			except:
+				print 'Some error happened.'
+		else:
+			print sys.argv[1] + " does not exist"	
+	else: 
+		print "Please enter an argument. Ex - rcmanager sample.xml"
 
 	sys.exit()
-


### PR DESCRIPTION
The rcmanager GUI window will not open unnecessarily now, if no argument (xml file name) is given or the xml file does not exist. It will also show appropriate error messages for the same. 