### PR TITLE
Update robotsimulatorcomp.cpp

### DIFF
--- a/tools/rcinnerModelSimulator/src/robotsimulatorcomp.cpp
+++ b/tools/rcinnerModelSimulator/src/robotsimulatorcomp.cpp
@@ -127,7 +127,7 @@ int robotSimulatorComp::run( int argc, char* argv[] )
 	if (port > 65535 or port < 0)
 		qFatal("Port number must be in the range 0-1023 (requires root privileges) or 1024-65535 (no privileges needed). Default port number: 11175");
 	if (ms > 1000 or ms < 5)
-		qFatal("Simulation period must be in the range 5-1000. Default period length 120ms");
+		qFatal("Simulation period must be in the range 5-1000. Default period length 30ms");
 
 	//Talk to STORM and setup mouse publishing stuff
 	IceStorm::TopicManagerPrx topicManager;


### PR DESCRIPTION
Corrected wrong error message. Default value for simulation period is 30 ms, although it is wrongly shown as 120ms.