### PR TITLE
Corrected filepaths in formManager.ui

### DIFF
--- a/tools/rcmanager/formManager.ui
+++ b/tools/rcmanager/formManager.ui
@@ -104,7 +104,7 @@
                  </property>
                  <property name="icon">
                   <iconset>
-                   <normaloff>../../../../../../../../../../../../opt/managerComp/share/down.png</normaloff>../../../../../../../../../../../../opt/managerComp/share/down.png</iconset>
+                   <normaloff>../../../../../../../../../../../../opt/robocomp/share/rcmanager/down.png</normaloff>../../../../../../../../../../../../opt/managerComp/share/down.png</iconset>
                  </property>
                 </widget>
                </item>
@@ -227,7 +227,7 @@
                  </property>
                  <property name="icon">
                   <iconset>
-                   <normaloff>../../../../../../../../../../../../opt/rcmanager/share/up.png</normaloff>../../../../../../../../../../../../opt/rcmanager/share/up.png</iconset>
+                   <normaloff>../../../../../../../../../../../../opt/robocomp/share/rcmanager/up.png</normaloff>../../../../../../../../../../../../opt/rcmanager/share/up.png</iconset>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
Corrected the absolute paths for up.png and down.png . Since the install directory in the CMakeLists.txt is /opt/robocomp/share , I hope this patch will be platform independent. 