### PR TITLE
Config file address resolved

### DIFF
--- a/tools/robocompdsl/templatePython/src/main.py
+++ b/tools/robocompdsl/templatePython/src/main.py
@@ -225,11 +225,19 @@ if __name__ == '__main__':
 ]]]
 [[[end]]]
 	params = copy.deepcopy(sys.argv)
+	#######config file path resolution#######
+	my_dir=params[0].split('/')[:-1]
+	cwd='/'.join(my_dir)
+	if cwd[-3:]=='src':
+		cwd=cwd[:-3]+'etc/'
+	else:
+		cwd+='../etc/'
+	##################################
 	if len(params) > 1:
 		if not params[1].startswith('--Ice.Config='):
 			params[1] = '--Ice.Config=' + params[1]
 	elif len(params) == 1:
-		params.append('--Ice.Config=config')
+		params.append('--Ice.Config='+cwd+'config')
 	ic = Ice.initialize(params)
 	status = 0
 	mprx = {}


### PR DESCRIPTION
Config file address resolved can be resolved automatically for default configuration.
The default config file lies in the etc folder of the project build which exists in the same level of src directory.
This change allows us to read from the sys.argv and figure out the address of the source file.
When that has been known all we do is move a step back in the directory tree and step into the etc folder to get our config.