### PR TITLE
Corrected wrong command in robocompdsl.md

### DIFF
--- a/doc/robocompdsl.md
+++ b/doc/robocompdsl.md
@@ -167,7 +167,7 @@ For c++,
 
 For Python,
 
-    python bin/mycomponent --Ice.Config=etc/config
+    python src/MyFirstComp.py --Ice.Config=etc/config
 
 and watch the robot avoiding obstacles! 
 Change the code to improve this simple behavior of the robot. Stop the component by closing its ui window, modify, recompile and execute again.


### PR DESCRIPTION
While making the component in Python, the bin folder was not generated. Also, the command "python bin/mycomponent" seems to be incorrect since python expects a .py file. I tested it using "python src/MyFirstComp.py" and it worked.