### PR TITLE
Corrected arrow direction in the new rcmanager (highlyUnstable branch)

### DIFF
--- a/tools/rcmanager/rcmanager.py
+++ b/tools/rcmanager/rcmanager.py
@@ -548,7 +548,7 @@ class MainClass(QtGui.QMainWindow):
 			raise Exception("No such component with alias "+alias)
 
 	
-	def setAconnection(self,fromComponent,toComponent):#To set these two components
+	def setAconnection(self,toComponent,fromComponent):#To set these two components
 		
 		connection=rcmanagerConfig.NodeConnection()
 		

--- a/tools/rcmanager/rcmanagerConfig.py
+++ b/tools/rcmanager/rcmanagerConfig.py
@@ -1633,8 +1633,8 @@ def getXmlFromNetwork(NetworkSettings, components,logger):
 		comp.x=comp.graphicsItem.x()
 		comp.y=comp.graphicsItem.y()
 		string=string+'\n\t<node alias="' + comp.alias + '" endpoint="' + comp.endpoint + '">\n'
-		for dep in comp.asEnd:
-			string=string+'\t\t<dependence alias="' + dep.fromComponent.alias + '" />\n'
+		for dep in comp.asBeg:
+			string=string+'\t\t<dependence alias="' + dep.toComponent.alias + '" />\n'
 		if comp.groupName!="":
 			string=string+'\t\t<group name="' + comp.groupName+ '" />\n'	
 		string=string+'\t\t<workingDir path="' + comp.workingdir + '" />\n'


### PR DESCRIPTION
Edited rcmanager.py and rcmanagerConfig.py to correct the direction of the arrow between components, according to the convention in the older rcmanager. If component A has a dependence on component B, the arrow should go from A to B and not the reverse. fixes #105 