### PR TITLE
Fix Issues in rcinnerModelEditor

### DIFF
--- a/tools/rcinnerModelEditor/src/specificworker.cpp
+++ b/tools/rcinnerModelEditor/src/specificworker.cpp
@@ -494,7 +494,7 @@ void SpecificWorker::interfaceConnections(bool enable)
 		connect(scaley, SIGNAL(valueChanged(double)), this, SLOT(meshChanged()));
 		connect(scalez, SIGNAL(valueChanged(double)), this, SLOT(meshChanged()));
 		// Plane-related
-		connect(texture, SIGNAL(editingFinished()), this, SLOT(meshChanged()));
+		connect(texture, SIGNAL(editingFinished()), this, SLOT(planeChanged()));
 		connect(px, SIGNAL(valueChanged(double)), this, SLOT(planeChanged()));
 		connect(py, SIGNAL(valueChanged(double)), this, SLOT(planeChanged()));
 		connect(pz, SIGNAL(valueChanged(double)), this, SLOT(planeChanged()));

--- a/tools/rcinnerModelEditor/src/specificworker.cpp
+++ b/tools/rcinnerModelEditor/src/specificworker.cpp
@@ -29,7 +29,7 @@ SpecificWorker::SpecificWorker(MapPrx& mprx) : GenericWorker(mprx)
 	QGLFormat fmt;
 	fmt.setDoubleBuffer(true);
 	QGLFormat::setDefaultFormat(fmt);
-	world3D = new OsgView(frame);
+	//world3D = new OsgView(frame);
 	connect(openpushButton,SIGNAL(clicked()),this, SLOT(openFile()));
 	connect(&timer, SIGNAL(timeout()), this, SLOT(compute()));
 	connect(create_new_nodepushButton, SIGNAL(clicked(bool)), this, SLOT(create_new_node(bool)));
@@ -572,6 +572,8 @@ void SpecificWorker::openFile()
 	if (fileName.isEmpty())
         return;
   else {
+	world3D = new OsgView(frame);
+	treeWidget->clear();
       innerModel = new InnerModel(fileName.toStdString());
 			fillNodeMap(innerModel->getNode("root"), NULL);
 			imv = new InnerModelViewer(innerModel, "root", world3D->getRootGroup(),false);


### PR DESCRIPTION
This pull request solve 2 issues:
1. after editing texture, tool was closing (segmentation fault)
2. If one open more than one innermodel file then they overlap