### PR TITLE
Change Travis from xenial to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: trusty
 language: cpp
 
 matrix:


### PR DESCRIPTION
As reported [here](https://github.com/travis-ci/travis-ci/issues/9080) xenial can cause problems with `apt-get install` with Travis tests. For now switching to trusty, a more supported system, might be the best.