### PR TITLE
fixes issue robocomp#172

### DIFF
--- a/tools/robocompdsl/parseCDSL.py
+++ b/tools/robocompdsl/parseCDSL.py
@@ -218,13 +218,13 @@ class CDSLParsing:
 		# Set options
 		component['options'] = []
 		try:
-			for op in tree['properties']['options']:
+			for op in tree['options']:
 				component['options'].append(op.lower())
 		except:
 			traceback.print_exc()
 
 		# Component name
-		component['name'] = tree['component']['name']
+		component['name'] = tree['name']
 		# Imports
 		component['imports'] = []
 		component['recursiveImports'] = []
@@ -267,7 +267,7 @@ class CDSLParsing:
 			# recursiveImports holds the necessary imports
 			importable = False
 			for interf in importedModule['interfaces']:
-				for comm in tree['properties']['communications']:
+				for comm in tree['communications']:
 					for interface in comm[1:]:
 						if communicationIsIce(interface):
 							if interf['name'] == interface[0]:
@@ -277,11 +277,11 @@ class CDSLParsing:
 				component['recursiveImports'] += [x for x in importedModule['imports'].split('#') if len(x)>0]
 
 		# Language
-		component['language'] = tree['properties']['language'][0]
+		component['language'] = tree['language'][0]
 		# qtVersion
 		component['useQt'] = 'none'
 		try:
-			component['useQt'] = tree['properties']['useQt'][0]
+			component['useQt'] = tree['useQt'][0]
 			pass
 		except:
 			pass
@@ -295,13 +295,13 @@ class CDSLParsing:
 		# GUI
 		component['gui'] = 'none'
 		try:
-			uiT = tree['properties']['gui'][0]
-			uiI = tree['properties']['gui'][1]
+			uiT = tree['gui'][0]
+			uiI = tree['gui'][1]
 			if uiT.lower() == 'qt' and uiI in ['QWidget', 'QMainWindow', 'QDialog' ]:
 				component['gui'] = [ uiT, uiI ]
 				pass
 			else:
-				print 'Wrong UI specification', tree['properties']['gui']
+				print 'Wrong UI specification', tree['gui']
 				sys.exit(1)
 		except:
 			pass
@@ -315,7 +315,7 @@ class CDSLParsing:
 		component['publishes']    = []
 		component['subscribesTo'] = []
 		component['usingROS'] = "None"
-		for comm in tree['properties']['communications']:
+		for comm in tree['communications']:
 			if comm[0] == 'implements':
 				for interface in comm[1:]:
 					component['implements'].append(interface)

--- a/tools/robocompdsl/parseIDSL.py
+++ b/tools/robocompdsl/parseIDSL.py
@@ -135,7 +135,7 @@ class IDSLParsing:
 		module = {}
 
 		#module name
-		module['name'] = tree['module']['name']
+		module['name'] = tree['name']
 
 		module['imports'] = ''
 		if 'imports' in tree:
@@ -147,7 +147,7 @@ class IDSLParsing:
 				module['imports'] += imp + '#' + IDSLParsing.gimmeIDSL(imp)['imports']
 		# INTERFACES DEFINED IN THE MODULE
 		module['interfaces'] = []
-		for contentDef in tree['module']['contents']:
+		for contentDef in tree['contents']:
 			if contentDef[0] == 'interface':
 				interface = { 'name':contentDef[1], 'methods':{}}
 				for method in contentDef[2]:
@@ -180,7 +180,7 @@ class IDSLParsing:
 		# TYPES DEFINED IN THE MODULE
 		module['types'] = []
 		#print '---\n---\nPARSE IDSL TYPES'
-		for contentDef in tree['module']['contents']:
+		for contentDef in tree['contents']:
 			#print contentDef[0]
 			if contentDef[0] in [ 'enum', 'struct', 'exception' ]:
 				typedef = { 'name':contentDef[1], 'type':contentDef[0]}
@@ -197,20 +197,20 @@ class IDSLParsing:
 		# SEQUENCES DEFINED IN THE MODULE
 		module['sequences'] = []
 		module['simpleSequences'] = []
-		for contentDef in tree['module']['contents']:
+		for contentDef in tree['contents']:
 			if contentDef['type'] == 'sequence':
-				seqdef       = { 'name':tree['module']['name']+"/"+contentDef['name'], 'type':contentDef['type']}
-				simpleSeqdef = { 'name':tree['module']['name'], 'strName':contentDef['name']}
+				seqdef       = { 'name':tree['name']+"/"+contentDef['name'], 'type':contentDef['type']}
+				simpleSeqdef = { 'name':tree['name'], 'strName':contentDef['name']}
 				#print structdef
 				module['sequences'].append(seqdef)
 				module['simpleSequences'].append(simpleSeqdef)
 		# STRUCTS DEFINED IN THE MODULE
 		module['structs'] = []
 		module['simpleStructs'] = []
-		for contentDef in tree['module']['contents']:
+		for contentDef in tree['contents']:
 			if contentDef['type'] == 'struct':
-				structdef       = { 'name':tree['module']['name']+"/"+contentDef['name'], 'type':contentDef['type']}
-				simpleStructdef = { 'name':tree['module']['name'], 'strName':contentDef['name']}
+				structdef       = { 'name':tree['name']+"/"+contentDef['name'], 'type':contentDef['type']}
+				simpleStructdef = { 'name':tree['name'], 'strName':contentDef['name']}
 				#print structdef
 				module['structs'].append(structdef)
 				module['simpleStructs'].append(simpleStructdef)


### PR DESCRIPTION
As currently robocompcdsl is not working with the new version 2.3 of pyparsing, I found that there was a difference in the ways that pyparsing v2.2 and pyparsing v2.3 parse a given text.
Specifically, in this case, pyparsing v2.2 was giving results with names appear multiple times, at different levels in the returned hierarchy. While, pyparsing v2.3 is giving cleaner structure as a result, with no duplication of names.
Please refer this for more details: [https://github.com/pyparsing/pyparsing/issues/43](https://github.com/pyparsing/pyparsing/issues/43)