### PR TITLE
Added missing path for QNetworkx graph in .gitmodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,5 @@
 	path = doc/robocomp-examples
 	url = https://github.com/robocomp/robocomp-examples.git
 [submodule "tools/rcmanager/widgets/QNetworkxGraph"]
+	path = tools/rcmanager/widgets/QNetworkxGraph
 	url = https://github.com/orensbruli/QNetworkxGraph.git

--- a/tools/rcmanager/main.py
+++ b/tools/rcmanager/main.py
@@ -74,6 +74,12 @@ class Main():
         self.model._logger.setLevel(verbosity_level)
         self.viewer._logger.setLevel(verbosity_level)
         self.controller._logger.setLevel(verbosity_level)
+
+    def set_viewer_profile_1(self, componentAlias):
+        return self.viewer.update_node_profile(componentAlias, 'Profile_1')
+            
+    def set_viewer_profile_2(self, componentAlias):
+        return self.viewer.update_node_profile(componentAlias, 'Profile_2')
         
     def setup_signal_connection(self):
         #TODO: it's a way to use a global variable. It should be avoided. Try to look for a better solution?
@@ -86,12 +92,8 @@ class Main():
         CustomSignalCollection.startComponent.connect(self.controller.start_component)
         CustomSignalCollection.stopComponent.connect(self.controller.stop_component)
         CustomSignalCollection.removeComponent.connect(self.controller.remove_component)
-
-        #TODO: Is there any non lambda connect solution?
-        CustomSignalCollection.componentRunning.connect(
-            lambda componentAlias: self.viewer.update_node_profile(componentAlias, 'Profile_1'))
-        CustomSignalCollection.componentStopped.connect(
-            lambda componentAlias: self.viewer.update_node_profile(componentAlias, 'Profile_2'))
+        CustomSignalCollection.componentRunning.connect(self.set_viewer_profile_1)
+        CustomSignalCollection.componentStopped.connect(self.set_viewer_profile_2)
 
 if __name__ == '__main__':
     # process params with a argparse

--- a/tools/rcmanager/viewer.py
+++ b/tools/rcmanager/viewer.py
@@ -37,6 +37,7 @@ from widgets import dialogs, code_editor, network_graph, menus
 from widgets.QNetworkxGraph.QNetworkxGraph import QNetworkxWidget, NodeShapes
 from logger import RCManagerLogger
 from rcmanagerSignals import CustomSignalCollection
+from functools import partial
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
@@ -182,8 +183,7 @@ class Viewer(QtGui.QMainWindow, MainWindow):
     # add buttons to the component list
     def add_to_component_list(self, node): 
         button = QPushButton(node, parent=None)
-        #TODO: Don't like lambdas on connects. Look for a better solution.
-        button.clicked.connect(lambda: self.on_button_click(node))
+        button.clicked.connect(partial(self.on_button_click, node))
         self.verticalLayout.insertWidget(self.verticalLayout.count()-1, button)
 
     def on_button_click(self, node):

--- a/tools/rcmanager/viewer.py
+++ b/tools/rcmanager/viewer.py
@@ -37,7 +37,6 @@ from widgets import dialogs, code_editor, network_graph, menus
 from widgets.QNetworkxGraph.QNetworkxGraph import QNetworkxWidget, NodeShapes
 from logger import RCManagerLogger
 from rcmanagerSignals import CustomSignalCollection
-from functools import partial
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
@@ -183,7 +182,8 @@ class Viewer(QtGui.QMainWindow, MainWindow):
     # add buttons to the component list
     def add_to_component_list(self, node): 
         button = QPushButton(node, parent=None)
-        button.clicked.connect(partial(self.on_button_click, node))
+        #TODO: Don't like lambdas on connects. Look for a better solution.
+        button.clicked.connect(lambda: self.on_button_click(node))
         self.verticalLayout.insertWidget(self.verticalLayout.count()-1, button)
 
     def on_button_click(self, node):


### PR DESCRIPTION
I found that there are two submodules in robocomp, "doc/robocomp-examples" and "tools/rcmanager/widgets/QNetworkxGraph", but, path attribute was missing for the "tools/rcmanager/widgets/QNetworkxGraph" submodule in the .gitmodules file which was preventing me to run git submodule init and update commands. Once I added the path I was able to run these commands and pull the QNetworkX code. 