### PR TITLE
 Added python library install for argcomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Make sure you have installed the following packages from the Ubuntu repository:
 
     sudo apt-get update
     sudo apt-get install git git-annex cmake g++ libgsl-dev libopenscenegraph-dev cmake-qt-gui zeroc-ice-all-dev freeglut3-dev libboost-system-dev libboost-thread-dev qt5-default libqt5xmlpatterns5-dev python-pip  python-pyparsing python-numpy libxt-dev libboost-test-dev libboost-filesystem-dev python-libxml2 python-xmltodict libccd-dev python-pyside pyside-tools python-zeroc-ice zeroc-ice-all-runtime
-    sudo pip install networkx pyside2
+    sudo pip install networkx pyside2 argcomplete
 
 It is recommendable to install the following packages::
 

--- a/doc/robocompdsl.md
+++ b/doc/robocompdsl.md
@@ -169,10 +169,10 @@ def compute(self):
 				self.differentialrobot_proxy.setSpeedBase(0, rot)
 			else:
 				self.differentialrobot_proxy.setSpeedBase(100, 0)
-		except Ice.Exception, e:
-			traceback.print_exc()
-			print e
-		return True
+	except Ice.Exception, e:
+		traceback.print_exc()
+		print e
+	return True
 ```
 
 Save the file.


### PR DESCRIPTION
The `argcomplete` library was not found when running `rcbuild`, `rccomp`, `rced` and `rcrun`.