### PR TITLE
Added missing path to submodule of QNetworkxGraph

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,5 @@
 	path = doc/robocomp-examples
 	url = https://github.com/robocomp/robocomp-examples.git
 [submodule "tools/rcmanager/widgets/QNetworkxGraph"]
+	path = tools/rcmanager/widgets/QNetworkxGraph
 	url = https://github.com/orensbruli/QNetworkxGraph.git


### PR DESCRIPTION
I found that there are two submodules in robocomp, "doc/robocomp-examples" and "tools/rcmanager/widgets/QNetworkxGraph", but, path attribute was missing for the "tools/rcmanager/widgets/QNetworkxGraph" submodule in the .gitmodules file which was preventing me to run git submodule init and update commands. Once I added the path I was able to pull the QNetworkX code from repository of @orensbruli  and the rcmanager was opening. 