### PR TITLE
Default innermodel to rcis

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Now let's run the simulator.
 
     cd ~/robocomp/files/innermodel
     rcis simpleworld.xml
+  
+You can also use the default innermodel simpleworld.xml anywhere if you have set the ROBOCOMP environment variable.
+
+    rcis
     
 Congratulations! RCIS should be up and running with a simple robot endowed with a laser and an RGBD camera, moving on a wooden floor. Don't forget to turn around the floor to see the robot from above.
  

--- a/tools/rcinnerModelSimulator/src/robotsimulatorcomp.cpp
+++ b/tools/rcinnerModelSimulator/src/robotsimulatorcomp.cpp
@@ -78,9 +78,8 @@
 #include "specificworker.h"
 #include <RCISMousePicker.h> 
 #include "ui_guiDlg.h"
-
-
-
+#include <cstdlib>
+#include <stdio.h>
 class robotSimulatorComp : public RoboComp::Application
 {
 private:
@@ -106,6 +105,22 @@ int robotSimulatorComp::run( int argc, char* argv[] )
 	printf("---------------------------------------\n");
 	printf("--- FCL_SUPPORT: %d\n", InnerModel::support_fcl());
 	printf("---------------------------------------\n");
+
+	string basic_inner_model;
+	if(std::getenv("ROBOCOMP"))
+	{
+		basic_inner_model=std::getenv("ROBOCOMP");
+		basic_inner_model+="/files/innermodel/simpleworld.xml";	
+	}
+	else
+		qFatal("Usage: %s InnerModelFile.xml [-p INNERMODEL_MANAGER_PORT] [-f MSECS]", argv[0]);
+	
+	if (!argv[1])
+	{
+		printf("Usage: %s InnerModelFile.xml [-p INNERMODEL_MANAGER_PORT] [-f MSECS]", argv[0]);
+		argv[1]=&basic_inner_model[0];
+
+	}
 
 	// Get the port number
 	int port = 11175;
@@ -199,9 +214,6 @@ int main(int argc, char* argv[])
 // 	bool hasConfig = false;
 	string arg;
 	robotSimulatorComp app;
-
-	if (argc < 2)
-		qFatal("Usage: %s InnerModelFile.xml [-p INNERMODEL_MANAGER_PORT] [-f MSECS]", argv[0]);
 
 	//  0 program_name
 	//  1 innermodel

--- a/tools/rcinnerModelSimulator/src/robotsimulatorcomp.cpp
+++ b/tools/rcinnerModelSimulator/src/robotsimulatorcomp.cpp
@@ -78,8 +78,6 @@
 #include "specificworker.h"
 #include <RCISMousePicker.h> 
 #include "ui_guiDlg.h"
-#include <cstdlib>
-#include <stdio.h>
 class robotSimulatorComp : public RoboComp::Application
 {
 private:

--- a/tools/rcinnerModelSimulator/src/robotsimulatorcomp.cpp
+++ b/tools/rcinnerModelSimulator/src/robotsimulatorcomp.cpp
@@ -118,6 +118,7 @@ int robotSimulatorComp::run( int argc, char* argv[] )
 	if (!argv[1])
 	{
 		printf("Usage: %s InnerModelFile.xml [-p INNERMODEL_MANAGER_PORT] [-f MSECS]", argv[0]);
+		printf("\nThe default simpleworld.xml was used, specify innermodel in the parameter parameter to use another.\n");
 		argv[1]=&basic_inner_model[0];
 
 	}


### PR DESCRIPTION
By adding the default innermodel, the rcis program can be called from anywhere if we have an environment variable. The default innermodel is simpleworld.xml. I added support for the lack of a ROBOCOMP environment variable.