### PR TITLE
Fix to run rcis with default innermodel

### DIFF
--- a/tools/rcinnerModelSimulator/src/robotsimulatorcomp.cpp
+++ b/tools/rcinnerModelSimulator/src/robotsimulatorcomp.cpp
@@ -105,16 +105,16 @@ int robotSimulatorComp::run( int argc, char* argv[] )
 	printf("---------------------------------------\n");
 
 	string basic_inner_model;
-	if(std::getenv("ROBOCOMP"))
-	{
-		basic_inner_model=std::getenv("ROBOCOMP");
-		basic_inner_model+="/files/innermodel/simpleworld.xml";	
-	}
-	else
-		qFatal("Usage: %s InnerModelFile.xml [-p INNERMODEL_MANAGER_PORT] [-f MSECS]", argv[0]);
-	
 	if (!argv[1])
 	{
+		if(std::getenv("ROBOCOMP"))
+		{
+			basic_inner_model=std::getenv("ROBOCOMP");
+			basic_inner_model+="/files/innermodel/simpleworld.xml";	
+		}
+		else
+			qFatal("Usage: %s InnerModelFile.xml [-p INNERMODEL_MANAGER_PORT] [-f MSECS]", argv[0]);
+
 		printf("Usage: %s InnerModelFile.xml [-p INNERMODEL_MANAGER_PORT] [-f MSECS]", argv[0]);
 		printf("\nThe default simpleworld.xml was used, specify innermodel in the parameter parameter to use another.\n");
 		argv[1]=&basic_inner_model[0];


### PR DESCRIPTION
Fix rcis run with parameter but without environment variable. On the previous version, this option threw the error unnecessarily.