### PR TITLE
Fixing recursive imports.

### DIFF
--- a/tools/robocompdsl/parseCDSL.py
+++ b/tools/robocompdsl/parseCDSL.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
-
 from pyparsing import Word, alphas, alphanums, nums, OneOrMore, CharsNotIn, Literal, Combine
 from pyparsing import cppStyleComment, Optional, Suppress, ZeroOrMore, Group, StringEnd, srange
-from pyparsing import nestedExpr, CaselessLiteral, CaselessKeyword, ParseBaseException 
+from pyparsing import nestedExpr, CaselessLiteral, CaselessKeyword, ParseBaseException
 from collections import Counter
 import sys, traceback, os
 debug = False
@@ -209,6 +208,7 @@ class CDSLParsing:
 		print '\t\tPublishes', component['publishes']
 		print '\t\tSubscribes', component['subscribesTo']
 
+	# TODO: Check if we can use lru_cache decorator.
 	@staticmethod
 	def generateRecursiveImports(initial_idsls,  include_directories):
 

--- a/tools/robocompdsl/templatePython/src/genericworker.py
+++ b/tools/robocompdsl/templatePython/src/genericworker.py
@@ -83,7 +83,12 @@ except:
 	pass
 
 [[[cog
-for imp in set(component['recursiveImports'] + component['requires'] + component['publishes'] + component['subscribesTo']):
+usingList = []
+for imp in set(component['recursiveImports'] + component["imports"]):
+	name = imp.split('/')[-1].split('.')[0]
+	if not name in usingList:
+		usingList.append(name)
+for name in usingList:
 	eso = imp.split('/')[-1]
 	incl = eso.split('.')[0]
 

--- a/tools/robocompdsl/templatePython/src/genericworker.py
+++ b/tools/robocompdsl/templatePython/src/genericworker.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 [[[cog
 
 import sys

--- a/tools/robocompdsl/templatePython/src/specificworker.py
+++ b/tools/robocompdsl/templatePython/src/specificworker.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 [[[cog
 
 import sys

--- a/tools/robocompdsl/templatePython/src/specificworker.py
+++ b/tools/robocompdsl/templatePython/src/specificworker.py
@@ -159,66 +159,72 @@ for imp in lst:
 						if first:
 							first = False
 					cog.out("]\n")
-for imp in component['implements']:
-	if type(imp) == str:
-		im = imp
-	else:
-		im = imp[0]
-	if not communicationIsIce(imp):
-		module = pool.moduleProviding(im)
-		for interface in module['interfaces']:
-			if interface['name'] == im:
-				for mname in interface['methods']:
-					method = interface['methods'][mname]
-					cog.outl('<TABHERE>def ROS' + method['name'] + "(self, req):")
-					cog.outl("<TABHERE><TABHERE>#")
-					cog.outl("<TABHERE><TABHERE>#implementCODE")
-					cog.outl("<TABHERE><TABHERE>#Example ret = req.a + req.b")
-					cog.outl("<TABHERE><TABHERE>#")
-					cog.outl("<TABHERE><TABHERE>return "+method['name']+"Response(ret)")
-	else:
-		module = pool.moduleProviding(im)
-		for interface in module['interfaces']:
-			if interface['name'] == im:
-				for mname in interface['methods']:
-					method = interface['methods'][mname]
-					outValues = []
-					if method['return'] != 'void':
-						outValues.append([method['return'], 'ret'])
-					paramStrA = ''
-					for p in method['params']:
-						if p['decorator'] == 'out':
-							outValues.append([p['type'], p['name']])
-						else:
-							paramStrA += ', ' +  p['name']
-					cog.outl('')
-					cog.outl('<TABHERE>#')
-					cog.outl('<TABHERE># ' + method['name'])
-					cog.outl('<TABHERE>#')
-					cog.outl('<TABHERE>def ' + method['name'] + '(self' + paramStrA + "):")
-					if method['return'] != 'void': cog.outl("<TABHERE><TABHERE>ret = "+method['return']+'()')
-					cog.outl("<TABHERE><TABHERE>#")
-					cog.outl("<TABHERE><TABHERE>#implementCODE")
-					cog.outl("<TABHERE><TABHERE>#")
-					if len(outValues) == 0:
-						cog.outl("<TABHERE><TABHERE>pass\n")
-					elif len(outValues) == 1:
+
+if component['implements']:
+	cog.out("# =============== Methods for Component Implements ==================")
+	cog.out("# ===================================================================")
+	for imp in component['implements']:
+		if type(imp) == str:
+			im = imp
+		else:
+			im = imp[0]
+		if not communicationIsIce(imp):
+			module = pool.moduleProviding(im)
+			for interface in module['interfaces']:
+				if interface['name'] == im:
+					for mname in interface['methods']:
+						method = interface['methods'][mname]
+						cog.outl('<TABHERE>def ROS' + method['name'] + "(self, req):")
+						cog.outl("<TABHERE><TABHERE>#")
+						cog.outl("<TABHERE><TABHERE># implementCODE")
+						cog.outl("<TABHERE><TABHERE># Example ret = req.a + req.b")
+						cog.outl("<TABHERE><TABHERE>#")
+						cog.outl("<TABHERE><TABHERE>return "+method['name']+"Response(ret)")
+		else:
+			module = pool.moduleProviding(im)
+			for interface in module['interfaces']:
+				if interface['name'] == im:
+					for mname in interface['methods']:
+						method = interface['methods'][mname]
+						outValues = []
 						if method['return'] != 'void':
-							cog.outl("<TABHERE><TABHERE>return ret\n")
+							outValues.append([method['return'], 'ret'])
+						paramStrA = ''
+						for p in method['params']:
+							if p['decorator'] == 'out':
+								outValues.append([p['type'], p['name']])
+							else:
+								paramStrA += ', ' +  p['name']
+						cog.outl('')
+						cog.outl('<TABHERE>#')
+						cog.outl('<TABHERE># ' + method['name'])
+						cog.outl('<TABHERE>#')
+						cog.outl('<TABHERE>def ' + method['name'] + '(self' + paramStrA + "):")
+						if method['return'] != 'void': cog.outl("<TABHERE><TABHERE>ret = "+method['return']+'()')
+						cog.outl("<TABHERE><TABHERE>#")
+						cog.outl("<TABHERE><TABHERE>#implementCODE")
+						cog.outl("<TABHERE><TABHERE>#")
+						if len(outValues) == 0:
+							cog.outl("<TABHERE><TABHERE>pass\n")
+						elif len(outValues) == 1:
+							if method['return'] != 'void':
+								cog.outl("<TABHERE><TABHERE>return ret\n")
+							else:
+								cog.outl("<TABHERE><TABHERE>"+outValues[0][1]+" = "+replaceTypeCPP2Python(outValues[0][0])+"()")
+								cog.outl("<TABHERE><TABHERE>return "+outValues[0][1]+"\n")
 						else:
-							cog.outl("<TABHERE><TABHERE>"+outValues[0][1]+" = "+replaceTypeCPP2Python(outValues[0][0])+"()")
-							cog.outl("<TABHERE><TABHERE>return "+outValues[0][1]+"\n")
-					else:
-						for v in outValues:
-							if v[1] != 'ret':
-								cog.outl("<TABHERE><TABHERE>"+v[1]+" = "+replaceTypeCPP2Python(v[0])+"()")
-						first = True
-						cog.out("<TABHERE><TABHERE>return [")
-						for v in outValues:
-							if not first: cog.out(', ')
-							cog.out(v[1])
-							if first:
-								first = False
-						cog.out("]\n")
+							for v in outValues:
+								if v[1] != 'ret':
+									cog.outl("<TABHERE><TABHERE>"+v[1]+" = "+replaceTypeCPP2Python(v[0])+"()")
+							first = True
+							cog.out("<TABHERE><TABHERE>return [")
+							for v in outValues:
+								if not first: cog.out(', ')
+								cog.out(v[1])
+								if first:
+									first = False
+							cog.out("]\n")
+	cog.out("# =============== Methods for Component Implements ==================")
+	cog.out("# ===================================================================")
 ]]]
 [[[end]]]


### PR DESCRIPTION
Previously recursive imports were generated assuming that name of the interfaces and the name of the files were the same. Also, includes and imports were generated based on this information on the components so, if there was a interface with different name, the component generation failed because there was no idsl with the name of the interface.