### PR TITLE
Migrate tutorial code snippets to Python 3

### DIFF
--- a/doc/code-examples/getting-started/python/Distance-measurement-python.md
+++ b/doc/code-examples/getting-started/python/Distance-measurement-python.md
@@ -38,14 +38,14 @@ The algorithm is as follows we move the bot randomly first and then collect the 
 		a.sort()
 		distance = d[0]
 		angle = a[0]
-		print distance
-		print angle
+		print(distance)
+		print(angle)
 		time.sleep(3)
 
 As told in the algorithm we first define the ldata, Start moving the bot randomly and collect the laser data, sort the distance only by appending it to a new list. Take the first element for the new list and output the same on the command window. Your final compute function will look something like this
 
 		def compute(self):
-		print 'SpecificWorker.compute...'
+		print('SpecificWorker.compute...')
 		try:
 			ldata = []
 			d= []
@@ -65,12 +65,12 @@ As told in the algorithm we first define the ldata, Start moving the bot randoml
 			a.sort()
 			distance = d[0]
 			angle = a[0]
-			print distance
-			print angle
+			print(distance)
+			print(angle)
 			time.sleep(3)
-		except Ice.Exception, e:
+		except Ice.Exception as e:
 			traceback.print_exc()
-			print e
+			print(e)
 		return True
 
 Save it and run the component by executing

--- a/doc/code-examples/getting-started/python/Keyboardrobotcontroller-python.md
+++ b/doc/code-examples/getting-started/python/Keyboardrobotcontroller-python.md
@@ -43,10 +43,10 @@ Define a parameter key which will get the input form the keyboard. If in case th
                	elif key == ord('q'):
 		    curses.endwin()
 		    sys.exit() 
-            except Ice.Exception, e:
+            except Ice.Exception as e:
 		curses.endwin()
                 traceback.print_exc()
-                print e
+                print(e)
             return True
 
 Save the code and simulate the innermodel simpleworld.xml and run the component by executing,

--- a/doc/code-examples/getting-started/python/moving-robot-in-a-square-and-circle-python.md
+++ b/doc/code-examples/getting-started/python/moving-robot-in-a-square-and-circle-python.md
@@ -50,15 +50,15 @@ This will set the speed of the bot to 100 and 0 radians per second. So to move i
 In the above code 1.5705 is ntn but 90 degrees written in radians per second and a 1 second delay is introduced or each setSpeedBase will execute for a second. Now you compute function should look like this
 
 		def compute(self):
-		print 'SpecificWorker.compute...'
+		print('SpecificWorker.compute...')
 		try:
 			self.differentialrobot_proxy.setSpeedBase(100, 0)
 			time.sleep(1)
 			self.differentialrobot_proxy.setSpeedBase(10, 1.5707)
 			time.sleep(1)
-		except Ice.Exception, e:
+		except Ice.Exception as e:
 			traceback.print_exc()
-			print e
+			print(e)
 		return True
 
 After you have written the algorithm as desired you can save the code and come back to the build folder

--- a/doc/code-examples/getting-started/python/moving-robot-in-a-square-and-circle-python.md
+++ b/doc/code-examples/getting-started/python/moving-robot-in-a-square-and-circle-python.md
@@ -50,7 +50,7 @@ This will set the speed of the bot to 100 and 0 radians per second. So to move i
 In the above code 1.5705 is ntn but 90 degrees written in radians per second and a 1 second delay is introduced or each setSpeedBase will execute for a second. Now you compute function should look like this
 
 		def compute(self):
-		print('SpecificWorker.compute...')
+		print('SpecificWorker.compute...')
 		try:
 			self.differentialrobot_proxy.setSpeedBase(100, 0)
 			time.sleep(1)
@@ -58,7 +58,7 @@ In the above code 1.5705 is ntn but 90 degrees written in radians per second and
 			time.sleep(1)
 		except Ice.Exception as e:
 			traceback.print_exc()
-			print(e)
+			print(e)
 		return True
 
 After you have written the algorithm as desired you can save the code and come back to the build folder

--- a/doc/code-examples/getting-started/python/obstacle-avoiding-bot-python.md
+++ b/doc/code-examples/getting-started/python/obstacle-avoiding-bot-python.md
@@ -14,7 +14,7 @@ Here rotation is set to a variable which keep changing in each loop. This is don
 The code for the above algorithm is
 
 		def compute(self):
-			print 'SpecificWorker.compute...'
+			print('SpecificWorker.compute...')
 			rot = 0.7
 			try:
 				ldata = []
@@ -26,7 +26,7 @@ The code for the above algorithm is
 					d.append(y)
 				d.sort()
 				distance = d[0]
-				print distance
+				print(distance)
 				if distance < 400:
 					self.differentialrobot_proxy.setSpeedBase(0, rot)
 					time.sleep(1)
@@ -38,9 +38,9 @@ The code for the above algorithm is
 				else:
 					self.differentialrobot_proxy.setSpeedBase(100, 0)
 					time.sleep(1)
-			except Ice.Exception, e:
+			except Ice.Exception as e:
 				traceback.print_exc()
-				print e
+				print(e)
 			return True
 
 Note that here the values set are arbitrary and can be changed according to your requirements. Save the file and in a new tab simulate a innermodel

--- a/doc/robocompdsl.md
+++ b/doc/robocompdsl.md
@@ -142,7 +142,8 @@ void SpecificWorker::compute( )
 ```
 save and, run cmake
 
-##Added the cmake command 
+## Added the cmake command 
+
 ```bash
     cd ..
     cmake .
@@ -154,7 +155,7 @@ Note that we are using a lambda function as a parameter to the std::sort functio
 If you have generated the code using python then, open *specificworker.py* in your favorite editor. Go to the **def compute(self):** method and replace it with,
 ```python
 def compute(self):
-	print 'SpecificWorker.compute...'
+	print('SpecificWorker.compute...')
 	rot = 0.7
 	try:
 		ldata = []
@@ -166,15 +167,15 @@ def compute(self):
 			d.append(y)
 			d.sort()
 			distance = d[0]
-			print distance
+			print(distance)
 			if distance < 400:
 				self.differentialrobot_proxy.setSpeedBase(0, rot)
 				time.sleep(1)
 			else:
 				self.differentialrobot_proxy.setSpeedBase(100, 0)
-	except Ice.Exception, e:
+	except Ice.Exception as e:
 		traceback.print_exc()
-		print e
+		print(e)
 	return True
 ```
 


### PR DESCRIPTION
The migration of the codebase to Python 3 left the tutorials broken, so this PR updates them to be compatible with Python3.

**WIP:** I've not checked all the examples yet, but the transformations I've done so far are simple and shouldn't have any errors.