### PR TITLE
Update robocompdsl tutorial description

### DIFF
--- a/doc/robocompdsl.md
+++ b/doc/robocompdsl.md
@@ -179,13 +179,8 @@ def compute(self):
 	return True
 ```
 
-Save the file and run cmake
+Save the file
 
-```bash
-    cd ..
-    cmake .
-    make
-```
 
 Now we need to tell the component where to find the DifferentialRobot and the Laser interfaces. Of course they are implemented by the rcis simulator, Run rcis <innemodel> and you can find the port numbers for each interface, so now we only need to change the ports in the configuration file. Copy the configuration file to your component home directory:
 


### PR DESCRIPTION
After coding the python specificworker.py file as per desired component, there is no need of running cmake and make commands. The generated file could be directly run as stated further in tutorial. Moreover, there is no cmakelist file being genrated as a part of template. This thing is even evident in the video provided in the tutorial. It creates a confusion among the new users thus it is important to correct it.