### PR TITLE
permissions issue fix

### DIFF
--- a/tools/buildTools/workspace.py
+++ b/tools/buildTools/workspace.py
@@ -423,8 +423,9 @@ class Workspace:
         home = os.path.expanduser("~")
         config_file_path = os.path.join(home, f".config/RoboComp/rc_{filename}.json")
         if not os.path.exists(os.path.join(home, ".config/RoboComp")):
-            os.makedirs(os.path.join(home, ".config/RoboComp"))
-
+            config_path = os.path.join(home, ".config/RoboComp")
+            os.makedirs(config_path)
+            os.chmod(config_path, 0o777)
         try:
             config_file = open(config_file_path, "w")
             json.dump(attr, config_file)
@@ -438,8 +439,9 @@ class Workspace:
         config_file_path = os.path.join(home, f".config/RoboComp/rc_{filename}.json")
 
         if not os.path.exists(os.path.join(home, ".config/RoboComp")):
-            os.makedirs(os.path.join(home, ".config/RoboComp"))
-
+            config_path = os.path.join(home, ".config/RoboComp")
+            os.makedirs(config_path)
+            os.chmod(config_path, 0o777)
         try:
             config_file = open(config_file_path, "r")
             attr = json.load(config_file)


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **development branch** (left side). Also you should start *your branch* off *our development*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] It's small enought so they can be easily reviewed.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

### Does this introduce a breaking change?
- [x] No

### Description
When robocomp is first installed using sudo make install, a directory is generated at .config/RoboComp, This directory however is write protected because was generated using sudo due to which any subsequent runs of rcworkspace -a give an error of permission denied, The PR solves this by giving the directory read write permissions to the said directory.
