### PR TITLE
Fix robocomp symlink creation when a symlink already exists

### DIFF
--- a/tools/install/robocomp_install.sh
+++ b/tools/install/robocomp_install.sh
@@ -3,7 +3,7 @@ branch="${branch:-development}"
 source <(curl -sL https://raw.githubusercontent.com/robocomp/robocomp/$branch/tools/install/resources/robocomp_prerequisites_install.sh)
 
 git clone -b $branch https://github.com/robocomp/robocomp.git
-sudo ln -s ~ /home/robocomp
+sudo ln -sfn ~ /home/robocomp
 echo "export ROBOCOMP=~/robocomp" >> ~/.bashrc
 echo "export PATH=$PATH:/opt/robocomp/bin" >> ~/.bashrc
 echo "export PYTHONIOENCODING=utf-8" >> ~/.bashrc


### PR DESCRIPTION
### Your checklist for this pull request

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **development branch** (left side). Also you should start *your branch* off *our development*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] I have added necessary documentation (if appropriate)
- [x] It's small enought so they can be easily reviewed.
- [ ] I have CONSIDERED or ADDED a unit test if the PR resolves an issue.

## Types of changes
What types of changes does your code introduce to Robocomp?  
<!-- Put an `x` (`[x]`) in the boxes that apply. -->
<!-- Usually only one, if not, consider to split your Pull Request). -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Documentation Update
- [ ] Build related changes
- [ ] Other (please describe):


### Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

### Does this close any currently open issues?
Issue ID: [ ]

### Description
Previously, a symlink would be created at /home/robocomp/$USER if a link from /home/$USER to /home/robocomp already existed. This PR fixes that, replacing any symlink at /home/robocomp if there is one.

===  
**Thank you!**
