### PR TITLE
Fixed over constrained occupied cells

### DIFF
--- a/classes/grid2d/grid.cpp
+++ b/classes/grid2d/grid.cpp
@@ -680,13 +680,14 @@ void Grid::update_costs(bool wide)
         {
             v.cost = 100;
             v.tile->setBrush(occ_brush);
-            for (auto neighs = neighboors_16(k); auto &&[kk, vv]: neighs)
-            {
-                fmap.at(kk).cost = 100;
-                fmap.at(kk).tile->setBrush(occ_brush);
-            }
+            // for (auto neighs = neighboors_8(k); auto &&[kk, vv]: neighs)
+            // {
+            //     fmap.at(kk).cost = 100;
+            //     fmap.at(kk).tile->setBrush(occ_brush);
+            // }
         }
         for (auto &&[k, v]: iter::filter([](auto v) { return std::get<1>(v).cost == 100; }, fmap))
+            
             for (auto neighs = neighboors_8(k); auto &&[kk, vv]: neighs)
             {
                 if (vv.cost < 100)
@@ -700,6 +701,7 @@ void Grid::update_costs(bool wide)
             {
                 if (vv.cost < 50)
                 {
+                    // vv.free = true;
                     fmap.at(kk).cost = 25;
                     fmap.at(kk).tile->setBrush(yellow_brush);
                 }
@@ -709,6 +711,7 @@ void Grid::update_costs(bool wide)
             {
                 if (vv.cost < 25)
                 {
+                    // vv.free = true;
                     fmap.at(kk).cost = 15;
                     fmap.at(kk).tile->setBrush(gray_brush);
                 }


### PR DESCRIPTION
1. Don't mark the neighbor cells of the occupied cells as obstacles. This made a bit more space in the map.
